### PR TITLE
Update joint_state_controller.cpp: clear joint_state_ before assignment

### DIFF
--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -70,6 +70,7 @@ namespace joint_state_controller
     realtime_pub_.reset(new realtime_tools::RealtimePublisher<sensor_msgs::JointState>(root_nh, "joint_states", 4));
 
     // get joints and allocate message
+    joint_state_.clear();
     for (unsigned i=0; i<num_hw_joints_; i++){
       joint_state_.push_back(hw->getHandle(joint_names[i]));
       realtime_pub_->msg_.name.push_back(joint_names[i]);


### PR DESCRIPTION
It seems like `joint_state_` should be cleared before assignment. Because the `init` function will be called again when the controller is reloaded.